### PR TITLE
fix: use ubuntu latest as default so build completes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build xrdp pulseaudio modules in builder container
 # See https://github.com/neutrinolabs/pulseaudio-module-xrdp/wiki/README
-ARG TAG=rolling
+ARG TAG=latest
 FROM ubuntu:$TAG as builder
 
 RUN sed -i -E 's/^# deb-src /deb-src /g' /etc/apt/sources.list \


### PR DESCRIPTION
Uses ubuntu 20.04 instead of 21.10 for builds and now completes without issues