### PR TITLE
Move user creation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,11 @@ ENV LANG en_US.UTF-8
 COPY --from=builder /usr/lib/pulse-*/modules/module-xrdp-sink.so /usr/lib/pulse-*/modules/module-xrdp-source.so /var/lib/xrdp-pulseaudio-installer/
 COPY entrypoint.sh /usr/bin/entrypoint
 EXPOSE 3389/tcp
+
+#
+# Create the user account
+RUN groupadd --gid 1020 ubuntu && \
+    useradd --shell /bin/bash --uid 1020 --gid 1020 --password $(openssl passwd ubuntu) --create-home --home-dir /home/ubuntu ubuntu && \
+    usermod -aG sudo ubuntu
+
 ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# Create the user account
-groupadd --gid 1020 ubuntu
-useradd --shell /bin/bash --uid 1020 --gid 1020 --password $(openssl passwd ubuntu) --create-home --home-dir /home/ubuntu ubuntu
-usermod -aG sudo ubuntu
-
 # Start xrdp sesman service
 /usr/sbin/xrdp-sesman
 


### PR DESCRIPTION
Hi

I wanted to install some application and setup some things when building my docker image that used docker-remote-desktop. But these commands I want to run as the ubuntu user. Since that user is created in ```entrypoint.sh``` the ubuntu user is not available during docker build phase. 

My proposal to this is to have the user created in Dockerfile and then my Dockerfile could look something like this, if my docker image needs to download an app from some where and unpack it in my home folder. Or do other things as the ubuntu user during build phase.

```Dockerfile
FROM scottyhardy/docker-remote-desktop
ENV DEBIAN_FRONTEND noninteractive
RUN apt-get update &&  \
    apt-get install -y \
    wget
USER ubuntu
RUN cd /home/ubuntu && \
    wget https://url-to-something/app.tar.gz && \
    tar -zxf app.tar.gz
USER root
``` 