### PR TITLE
fix default locale and remove direct declaration of dependence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,11 @@ RUN apt-get update && \
         locales \
         pavucontrol \
         pulseaudio \
-        pulseaudio-utils \
         software-properties-common \
         sudo \
         vim \
-        x11-xserver-utils \
         xfce4 \
         xfce4-goodies \
-        xfce4-pulseaudio-plugin \
         xorgxrdp \
         xrdp \
         xubuntu-icon-theme && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,12 @@ RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends firefox && \
     rm -rf /var/lib/apt/lists/* && \
     deluser --remove-home ubuntu && \
-    locale-gen en_US.UTF-8
+    locale-gen en_US.UTF-8 && \
+    echo 'LANG=en_US.UTF-8' > /etc/default/locale
 
 COPY --from=builder /tmp/install /
 RUN sed -i 's|^Exec=.*|Exec=/usr/bin/pulseaudio|' /etc/xdg/autostart/pulseaudio-xrdp.desktop
 
-ENV LANG=en_US.UTF-8
 COPY entrypoint.sh /usr/bin/entrypoint
 EXPOSE 3389/tcp
 ENTRYPOINT ["/usr/bin/entrypoint"]


### PR DESCRIPTION
### remove direct declaration of dependence
don't need direct declare
> pulseaudio -> pulseaudio-utils
xfce4 -> xfce4-session -> x11-xserver-utils
xfce4 -> xfce4-pulseaudio-plugin

### default locale
Although locale-gen and declaring env, but default is still C.UTF-8
> $ echo $LANG
C.UTF-8
$ cat /etc/default/locale 
LANG=C.UTF-8
$ locale
LANG=C.UTF-8
LANGUAGE=
LC_CTYPE="C.UTF-8"
LC_NUMERIC="C.UTF-8"
...

